### PR TITLE
feat: Task 1 - プロジェクトの初期設定

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,0 +1,3 @@
+from fastapi import FastAPI
+
+app = FastAPI(title="商品管理API")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,3 +119,8 @@ exclude = ["**/node_modules", "**/__pycache__", ".venv"]
 reportMissingTypeStubs = false
 typeCheckingMode = "basic"
 
+[dependency-groups]
+dev = [
+    "fastapi>=0.115.13",
+]
+

--- a/tests/api/test_main.py
+++ b/tests/api/test_main.py
@@ -1,0 +1,10 @@
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from api.main import app
+
+
+@pytest.mark.anyio
+async def test_sample() -> None:
+    """仮のテスト"""
+    assert True

--- a/uv.lock
+++ b/uv.lock
@@ -257,6 +257,11 @@ ui = [
     { name = "streamlit" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "fastapi" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "anyio", marker = "extra == 'dev'", specifier = ">=3.0.0" },
@@ -278,6 +283,9 @@ requires-dist = [
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'api'", specifier = ">=0.23.0" },
 ]
 provides-extras = ["api", "ui", "dev", "all"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "fastapi", specifier = ">=0.115.13" }]
 
 [[package]]
 name = "distlib"


### PR DESCRIPTION
## 概要
Task #1 の実装

## 関連Issue
Fixes #1

## 実装内容
- ✅ `api/main.py` の作成
- ✅ `tests/api/test_main.py` の作成
- ✅ テスト実行に必要な `fastapi` 依存関係を `dev` グループに追加