### PR TITLE
feat: Task 2 - ヘルスチェックエンドポイントの実装

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,3 +1,9 @@
 from fastapi import FastAPI
 
 app = FastAPI(title="商品管理API")
+
+
+@app.get("/health", status_code=200)
+async def health_check() -> dict[str, str]:
+    """ヘルスチェックエンドポイント"""
+    return {"status": "ok"}

--- a/tests/api/test_main.py
+++ b/tests/api/test_main.py
@@ -5,6 +5,9 @@ from api.main import app
 
 
 @pytest.mark.anyio
-async def test_sample() -> None:
-    """仮のテスト"""
-    assert True
+async def test_health_check_returns_200() -> None:
+    """/health にGETリクエストを送信すると、ステータスコード200と{"status": "ok"}が返ること"""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}


### PR DESCRIPTION
## 概要
Task #2 の実装

## 関連Issue
Fixes #2

## 実装内容
- ✅ TDDサイクル（Red -> Green）に従って `/health` エンドポイントを実装
- ✅ 正常に `200 OK` と `{"status": "ok"}` を返すことをテストで確認