### PR TITLE
feat: Task 5 - 商品作成エンドポイントの実装（正常系）

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,6 +1,16 @@
 from fastapi import FastAPI
 
+from .models import Product, ProductCreate
+from .storage import InMemoryStorage
+
 app = FastAPI(title="商品管理API")
+storage = InMemoryStorage()
+
+
+@app.post("/items", response_model=Product, status_code=201)
+async def create_item(item: ProductCreate) -> Product:
+    """商品を作成する"""
+    return storage.create_product(item)
 
 
 @app.get("/health", status_code=200)

--- a/api/storage.py
+++ b/api/storage.py
@@ -1,4 +1,4 @@
-from .models import Product
+from .models import Product, ProductCreate
 
 
 class InMemoryStorage:
@@ -7,3 +7,10 @@ class InMemoryStorage:
     def __init__(self) -> None:
         self._products: dict[int, Product] = {}
         self._next_id: int = 1
+
+    def create_product(self, product_create: ProductCreate) -> Product:
+        """商品を作成して保存する"""
+        product = Product(id=self._next_id, **product_create.model_dump())
+        self._products[self._next_id] = product
+        self._next_id += 1
+        return product

--- a/tests/api/test_main.py
+++ b/tests/api/test_main.py
@@ -5,6 +5,20 @@ from api.main import app
 
 
 @pytest.mark.anyio
+async def test_create_product_returns_201_and_created_product() -> None:
+    """商品作成リクエストを送信すると、ステータスコード201と作成された商品情報が返ること"""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post("/items", json={"name": "テスト商品", "price": 1000})
+
+    assert response.status_code == 201
+    data = response.json()
+    assert "id" in data
+    assert "created_at" in data
+    assert data["name"] == "テスト商品"
+    assert data["price"] == 1000
+
+
+@pytest.mark.anyio
 async def test_health_check_returns_200() -> None:
     """/health にGETリクエストを送信すると、ステータスコード200と{"status": "ok"}が返ること"""
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:


### PR DESCRIPTION
## 概要
Task #5 の実装

## 関連Issue
Fixes #5

## 実装内容
- ✅ TDDで商品作成エンドポイント (`POST /items`) を実装
- ✅ `InMemoryStorage` に商品を作成するロジックを追加
- ✅ テストでステータスコード`201`と作成された商品データが返ることを確認