### PR TITLE
test: Task 6 - 商品作成時のバリデーションテスト

### DIFF
--- a/tests/api/test_main.py
+++ b/tests/api/test_main.py
@@ -4,6 +4,27 @@ from httpx import ASGITransport, AsyncClient
 from api.main import app
 
 
+@pytest.mark.parametrize(
+    ("payload", "error_message"),
+    [
+        ({"name": "", "price": 1000}, "String should have at least 1 character"),
+        ({"name": "テスト商品", "price": 0}, "Input should be greater than 0"),
+        ({"name": "テスト商品", "price": -1}, "Input should be greater than 0"),
+    ],
+)
+@pytest.mark.anyio
+async def test_create_product_with_invalid_data_returns_422(
+    payload: dict[str, str | int],
+    error_message: str,
+) -> None:
+    """不正なデータで商品作成リクエストを送信すると、ステータスコード422とエラーメッセージが返ること"""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post("/items", json=payload)
+
+    assert response.status_code == 422
+    assert error_message in response.text
+
+
 @pytest.mark.anyio
 async def test_create_product_returns_201_and_created_product() -> None:
     """商品作成リクエストを送信すると、ステータスコード201と作成された商品情報が返ること"""


### PR DESCRIPTION
## 概要
Task #6 の実装

## 関連Issue
Fixes #6

## 実装内容
- ✅ `pytest.mark.parametrize` を使用して、商品作成時の不正なデータ（空の名前、0以下の価格）に対するバリデーションテストを追加
- ✅ Pydanticモデルによって`422 Unprocessable Entity`が正しく返されることを確認