### PR TITLE
feat: Task 7 - 商品取得エンドポイントの実装（正常系）

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 
 from .models import Product, ProductCreate
 from .storage import InMemoryStorage
@@ -11,6 +11,15 @@ storage = InMemoryStorage()
 async def create_item(item: ProductCreate) -> Product:
     """商品を作成する"""
     return storage.create_product(item)
+
+
+@app.get("/items/{item_id}", response_model=Product)
+async def get_item(item_id: int) -> Product:
+    """IDで商品を取得する"""
+    product = storage.get_product(item_id)
+    if product is None:
+        raise HTTPException(status_code=404, detail="Product not found")
+    return product
 
 
 @app.get("/health", status_code=200)

--- a/api/storage.py
+++ b/api/storage.py
@@ -14,3 +14,7 @@ class InMemoryStorage:
         self._products[self._next_id] = product
         self._next_id += 1
         return product
+
+    def get_product(self, product_id: int) -> Product | None:
+        """IDで商品を検索する"""
+        return self._products.get(product_id)

--- a/tests/api/test_main.py
+++ b/tests/api/test_main.py
@@ -46,3 +46,23 @@ async def test_health_check_returns_200() -> None:
         response = await client.get("/health")
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
+
+
+@pytest.mark.anyio
+async def test_get_product_returns_200_and_product() -> None:
+    """存在する商品IDでGETリクエストを送信すると、ステータスコード200と商品情報が返ること"""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        # まず商品を作成
+        payload = {"name": "取得用テスト商品", "price": 500}
+        create_response = await client.post("/items", json=payload)
+        assert create_response.status_code == 201
+        created_product_id = create_response.json()["id"]
+
+        # 作成した商品を取得
+        get_response = await client.get(f"/items/{created_product_id}")
+
+    assert get_response.status_code == 200
+    data = get_response.json()
+    assert data["id"] == created_product_id
+    assert data["name"] == "取得用テスト商品"
+    assert data["price"] == 500


### PR DESCRIPTION
## 概要
Task #7 の実装

## 関連Issue
Fixes #7

## 実装内容
- ✅ TDDで商品取得エンドポイント (`GET /items/{id}`) を実装
- ✅ `InMemoryStorage` に商品を取得するロジックを追加
- ✅ テストでステータスコード`200`と正しい商品データが返ることを確認