### PR TITLE
feat: Task 10 - APIステータス表示機能の実装

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,5 +123,7 @@ typeCheckingMode = "basic"
 [dependency-groups]
 dev = [
     "fastapi>=0.115.13",
+    "pytest-httpx>=0.35.0",
+    "streamlit>=1.46.1",
 ]
 

--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -1,0 +1,32 @@
+import httpx
+import pytest
+from httpx import Response
+from pytest_httpx import HTTPXMock
+
+from ui.main import check_api_status
+
+# APIのエンドポイントURL
+API_URL = "http://localhost:8000"
+
+
+@pytest.mark.asyncio
+async def test_check_api_status_success(httpx_mock: HTTPXMock) -> None:
+    """APIが正常な場合にTrueを返すことをテストする"""
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{API_URL}/health",
+        status_code=200,
+        json={"status": "ok"},
+    )
+
+    status = await check_api_status()
+    assert status is True
+
+
+@pytest.mark.asyncio
+async def test_check_api_status_failure(httpx_mock: HTTPXMock) -> None:
+    """APIが利用不可能な場合にFalseを返すことをテストする"""
+    httpx_mock.add_exception(httpx.ConnectError("Connection failed"))
+
+    status = await check_api_status()
+    assert status is False

--- a/ui/main.py
+++ b/ui/main.py
@@ -1,4 +1,19 @@
+import asyncio
+
+import httpx
 import streamlit as st
+
+API_URL = "http://localhost:8000"
+
+
+async def check_api_status() -> bool:
+    """APIサーバーの稼働状況を確認する"""
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(f"{API_URL}/health")
+            return response.status_code == 200
+    except httpx.ConnectError:
+        return False
 
 
 def main() -> None:
@@ -11,6 +26,12 @@ def main() -> None:
 
     # ヘッダー
     st.header("商品管理ダッシュボード")
+
+    # APIステータス表示
+    if asyncio.run(check_api_status()):
+        st.success("API正常稼働中")
+    else:
+        st.error("API接続エラー")
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -261,6 +261,8 @@ ui = [
 [package.dev-dependencies]
 dev = [
     { name = "fastapi" },
+    { name = "pytest-httpx" },
+    { name = "streamlit" },
 ]
 
 [package.metadata]
@@ -287,7 +289,11 @@ requires-dist = [
 provides-extras = ["api", "ui", "dev", "all"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "fastapi", specifier = ">=0.115.13" }]
+dev = [
+    { name = "fastapi", specifier = ">=0.115.13" },
+    { name = "pytest-httpx", specifier = ">=0.35.0" },
+    { name = "streamlit", specifier = ">=1.46.1" },
+]
 
 [[package]]
 name = "distlib"
@@ -899,6 +905,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/18/99/668cade231f434aaa59bbfbf49469068d2ddd945000621d3d165d2e7dd7b/pytest_cov-6.2.1.tar.gz", hash = "sha256:25cc6cc0a5358204b8108ecedc51a9b57b34cc6b8c967cc2c01a4e00d8a67da2", size = 69432, upload-time = "2025-06-12T10:47:47.684Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/16/4ea354101abb1287856baa4af2732be351c7bee728065aed451b678153fd/pytest_cov-6.2.1-py3-none-any.whl", hash = "sha256:f5bc4c23f42f1cdd23c70b1dab1bbaef4fc505ba950d53e0081d0730dd7e86d5", size = 24644, upload-time = "2025-06-12T10:47:45.932Z" },
+]
+
+[[package]]
+name = "pytest-httpx"
+version = "0.35.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/89/5b12b7b29e3d0af3a4b9c071ee92fa25a9017453731a38f08ba01c280f4c/pytest_httpx-0.35.0.tar.gz", hash = "sha256:d619ad5d2e67734abfbb224c3d9025d64795d4b8711116b1a13f72a251ae511f", size = 54146, upload-time = "2024-11-28T19:16:54.237Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/ed/026d467c1853dd83102411a78126b4842618e86c895f93528b0528c7a620/pytest_httpx-0.35.0-py3-none-any.whl", hash = "sha256:ee11a00ffcea94a5cbff47af2114d34c5b231c326902458deed73f9c459fd744", size = 19442, upload-time = "2024-11-28T19:16:52.787Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 概要
Task #10 の実装

## 関連Issue
Fixes #18

## 実装内容
- [x] TDDに基づき、APIの稼働状況をチェックするロジック (`check_api_status`) を実装
- [x] API成功時と接続失敗時の両方をカバーするテストを作成
- [x] `check_api_status` の結果をUIに表示し、「API正常稼働中」または「API接続エラー」メッセージを表示する機能を実装
- [x] `pytest`のインポート競合を避けるため、UIテストファイル名を`test_ui.py`に変更