### PR TITLE
feat: Task 11 - 商品登録フォームの実装

### DIFF
--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -3,7 +3,7 @@ import pytest
 from httpx import Response
 from pytest_httpx import HTTPXMock
 
-from ui.main import check_api_status
+from ui.main import Product, check_api_status, register_product
 
 # APIのエンドポイントURL
 API_URL = "http://localhost:8000"
@@ -30,3 +30,28 @@ async def test_check_api_status_failure(httpx_mock: HTTPXMock) -> None:
 
     status = await check_api_status()
     assert status is False
+
+
+@pytest.mark.asyncio
+async def test_register_product_success(httpx_mock: HTTPXMock) -> None:
+    """商品登録が成功するケースをテストする"""
+    product_data = {"name": "テスト商品", "price": 1000}
+    response_data = {
+        "id": 1,
+        "name": "テスト商品",
+        "price": 1000,
+        "created_at": "2023-01-01T00:00:00Z",
+    }
+
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{API_URL}/items",
+        status_code=201,
+        json=response_data,
+    )
+
+    result = await register_product(product_data["name"], product_data["price"])
+
+    assert isinstance(result, Product)
+    assert result.name == product_data["name"]
+    assert result.price == product_data["price"]


### PR DESCRIPTION
## 概要
Task #11 の実装

## 関連Issue
Fixes #19

## 実装内容
- [x] TDDに基づき、商品登録を行う`register_product`関数を実装
- [x] Streamlit UIに商品登録フォーム (`st.form`) を追加
- [x] 登録ボタンクリックでAPIを呼び出すロジックを実装
- [x] インポート問題を回避するため、UIに必要なPydanticモデルを`ui/main.py`内に定義